### PR TITLE
Update Converting MPC audio files to MP3.md

### DIFF
--- a/content/wiki/Converting MPC audio files to MP3.md
+++ b/content/wiki/Converting MPC audio files to MP3.md
@@ -6,6 +6,8 @@ Notes made while finding out how to convert [MPC](/wiki/MPC) files to another fo
 
 # Obtaining [mppdec](/wiki/mppdec)
 
+# NOTE: mppdc only runs on PowerPC cpu's (you have to find a very old mac to run it on)
+
 At the time of writing version 1.95z2 is the latest available version of [mppdec](/wiki/mppdec).
 
 -   <http://www.musepack.net/index.php?pg=osx>


### PR DESCRIPTION
Most folks have forgotten that mppdc only runs on PowerPC cpu's (you have to find a very old mac to run it on). So I added this note to the top.